### PR TITLE
Fix handling for inline-edit rows

### DIFF
--- a/admin_async_upload/files.py
+++ b/admin_async_upload/files.py
@@ -5,7 +5,7 @@ import tempfile
 
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
-from django.core.files.storage import FileSystemStorage, default_storage
+from django.core.files.storage import default_storage
 from django.utils.module_loading import import_string
 
 
@@ -27,7 +27,7 @@ class ResumableFile(object):
         self.chunk_suffix = "_part_"
         chunk_storage_class = getattr(settings, 'ADMIN_RESUMABLE_CHUNK_STORAGE', None)
         if chunk_storage_class is None:
-            self.chunk_storage = FileSystemStorage()
+            self.chunk_storage = self.field.storage or default_storage
         else:
             self.chunk_storage = import_string(chunk_storage_class)()
         self.field_storage = self.field.storage or default_storage

--- a/admin_async_upload/templates/admin_resumable/admin_file_input.html
+++ b/admin_async_upload/templates/admin_resumable/admin_file_input.html
@@ -87,9 +87,12 @@ if (typeof djangoAdminResumableFieldListenerSetUp=="undefined")
         For new inlines it will be replace with a placeholder that will be updated by page js.
         That's why we use formset:added event - to get the actual id that is generated
         by django-admin's inlines.js code
-        {% endcomment %}
-        //FIXME: don't execute if id contains "__prefix__" - django's placeholder for id
-        setupField('{{ id }}');
+{% endcomment %}
+        // Don't execute if id contains "__prefix__" - django's placeholder for id
+        var id = '{{ id }}';
+        if (!id.includes('__prefix__')) {
+            setupField('{{ id }}');
+        }
     });
 
     //should be set up once
@@ -97,9 +100,9 @@ if (typeof djangoAdminResumableFieldListenerSetUp=="undefined")
     {
         //setup admin inline creation listener so we can get the id of created fields instead
         // of a placeholder stored in { id } for new fields
-        $(document).on('formset:added', function(event, $row, formsetName) {
+        $(document).on('formset:added', function(event, row, formsetName) {
             //check if there are resumable fields and set them up with their actual ids
-            $row.find('input.django-admin-resumable-file').each(
+            $(event.target).find('input.django-admin-resumable-file').each(
                 function () {
                     let el = $(this);
                     let strippedId = el.attr('id').replace('_input_file', '');
@@ -121,9 +124,7 @@ if (typeof djangoAdminResumableFieldListenerSetUp=="undefined")
             {% trans 'Currently' %}:
             {% if file_url %}
                 <a id="{{ id }}_link" target="_new" href="{{ file_url }}">{{ file_name }}</a>
-                {% if show_thumb %}
-                    <img src="{{ file_url }}" style="width:250px;">
-                {% endif %}
+                {% if show_thumb %}<img src="{{ file_url }}" style="width:250px;">{% endif %}
             {% else %}
                 {{ value }}
             {% endif %}
@@ -131,11 +132,11 @@ if (typeof djangoAdminResumableFieldListenerSetUp=="undefined")
             <br>
             {% trans 'Change' %}:
         {% endif %}
-
         <span id="{{ id }}_uploaded_status"></span>
-        <input type="file" id="{{ id }}_input_file" class="django-admin-resumable-file">
+        <input type="file"
+               id="{{ id }}_input_file"
+               class="django-admin-resumable-file">
     </p>
     <progress id="{{ id }}_progress" value="0" max="1" style="width:500px"></progress>
 </div>
-
 <input type="hidden" name="{{ name }}" id="{{ id }}" value="{{ value }}">

--- a/admin_async_upload/views.py
+++ b/admin_async_upload/views.py
@@ -31,7 +31,7 @@ class UploadView(View):
     def get(self, request, *args, **kwargs):
         r = ResumableFile(self.model_upload_field, user=request.user, params=request.GET)
         if not r.chunk_exists:
-            return HttpResponse('chunk not found', status=404)
+            return HttpResponse('chunk not found', status=204)
         if r.is_complete:
             return HttpResponse(r.collect())
         return HttpResponse('chunk exists')


### PR DESCRIPTION
The previous `formset:added` handler was referencing an undefined value (and seemed to just be an error in general). I've changed it to reference the target element and search as appropriate, and it seems to now properly allow inline added forms.